### PR TITLE
Change dependency onto version:vpp and version::vxs from version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,8 @@ requires 'File::Spec' => 0;
 requires 'File::Temp' => 0;
 requires 'JSON::PP' => '2.00';
 requires 'Safe' => 0;
-requires 'version' => '0.79';
+requires 'version::vpp' => '0.79';
+requires 'version::vxs' => '0.79';
 
 on test => sub {
   requires 'Test::More' => '0.88';


### PR DESCRIPTION
version.pm which is installed in core doesn't contain `version:vpp` and `version::vxs`, thus it cannot call some functions (e.g. `version::vpp::vcmp`, `version::vxs::VCMP`, and more) and fail tests.
