### PR TITLE
Add global modifier to package name substitution

### DIFF
--- a/lib/Parse/PMFile.pm
+++ b/lib/Parse/PMFile.pm
@@ -397,7 +397,7 @@ sub _packages_per_pmfile {
             # Found something
 
             # from package
-            $pkg =~ s/\'/::/;
+            $pkg =~ s/\'/::/g;
             next PLINE unless $pkg =~ /^[A-Za-z]/;
             next PLINE unless $pkg =~ /\w$/;
             next PLINE if $pkg eq "main";

--- a/t/41_multiple_packages.t
+++ b/t/41_multiple_packages.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Test::More;
+use Parse::PMFile;
+use File::Temp;
+
+my $tmpdir = File::Temp->newdir(CLEANUP => 1);
+plan skip_all => "tmpdir is not ready" unless -e $tmpdir && -w $tmpdir;
+
+my $pmfile = "$tmpdir/Test.pm";
+my @package = (qw/Parse PMFile Test/);
+my @subpackages = (qw/Location Blah Thing/);
+
+my $parser = Parse::PMFile->new;
+subtest 'arisdottle' => sub {
+  _generate_package(q{::});
+  my $info = $parser->parse($pmfile);
+  _check_packages($info);
+};
+
+subtest 'quote' => sub {
+  _generate_package(q{'});
+  my $info = $parser->parse($pmfile);
+  _check_packages($info);
+};
+
+done_testing;
+
+sub _generate_package {
+  my ($sep) = @_;
+  my $version = 1;
+
+  open my $fh, '>', $pmfile or plan skip_all => "Failed to create a pmfile";
+  print $fh 'package ' . join($sep, @package) . ";\n";
+  print $fh q{our $VERSION = '1.0} . $version++ . "';\n1;\n";
+  for my $subpackage (@subpackages) {
+    print $fh 'package ' . join($sep, @package, $subpackage) . ";\n";
+    print $fh q{our $VERSION = '1.0} . $version++ . "';\n1;\n";
+  }
+  close $fh;
+}
+
+sub _check_packages {
+	my ($info) = @_;
+
+	my $package = join(q{::}, @package);
+	ok exists $info->{$package}, q{found base package};
+
+	for my $subpackage (@subpackages) {
+		ok exists $info->{$package . q{::} . $subpackage}, qq{found sub package $subpackage};
+	}
+}


### PR DESCRIPTION
In _packages_per_pmfile package names get normalised to the arisdottle
format so a package My'Test would be normalised to My::Test.
Unfortunately My'Test'Package would get normalised to My::Test'Package
rather than My::Test::Package. If we add the global modifier to the package
name substitution all the single quotes will be converted to arisdottles.